### PR TITLE
chore(CODEOWNERS): assign platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/platform


### PR DESCRIPTION
Marking this as platform since `pco-box` is owned by platform.